### PR TITLE
inject google maps api key at build time

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,12 @@ jobs:
       - uses: actions/configure-pages@v5
         id: pages
 
+      - name: Inject Google Maps API key
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+        run: |
+          sed -i "s|^  google-maps:.*|  google-maps: ${GOOGLE_MAPS_API_KEY}|" _config.yml
+
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:

--- a/_config.yml
+++ b/_config.yml
@@ -146,4 +146,4 @@ footer_links:
     icon: fas fa-rss-square
 
 extras:
-  google-maps: AIzaSyBMXCGJ0v88uCZmZVUmJYe6GB5FfofeJuo
+  google-maps:


### PR DESCRIPTION
## Summary
- Removes hardcoded Google Maps API key from `_config.yml`
- Adds a workflow step that injects `${{ secrets.GOOGLE_MAPS_API_KEY }}` into `_config.yml` via `sed` before `jekyll build`
- Stops GitHub secret scanning from alerting on every push

Key was rotated in GCP and locked with HTTP-referrer + Maps JS API restrictions prior to this change. Old alert will be dismissed as revoked after merge.

## Test plan
- [ ] Pages workflow runs green on merge
- [ ] Verify maps render on production post pages (e.g. death-valley, london-stonehenge, arizona-moab-utah, motorcycling-abroad)